### PR TITLE
Revert "Fix Control tab temperature setting"

### DIFF
--- a/klippy/extras/e3v3se_display.py
+++ b/klippy/extras/e3v3se_display.py
@@ -2209,7 +2209,7 @@ class E3v3seDisplay:
                     self.MBASE(temp_line) - 8,
                     self.pd.HMI_ValueStruct.E_Temp,
                 )
-                self.pd.setExtTemp(self.pd.HMI_ValueStruct.E_Temp, 0)
+                self.pd.setTargetHotend(self.pd.HMI_ValueStruct.E_Temp, 0)
             return
         elif encoder_state == self.ENCODER_DIFF_CW:
             self.pd.HMI_ValueStruct.E_Temp += 1
@@ -2315,7 +2315,7 @@ class E3v3seDisplay:
                     self.MBASE(bed_line) - 8,
                     self.pd.HMI_ValueStruct.Bed_Temp,
                 )
-                self.pd.setBedTemp(self.pd.HMI_ValueStruct.Bed_Temp, 0)
+                self.pd.setTargetHotend(self.pd.HMI_ValueStruct.Bed_Temp, 0)
             return
         elif encoder_state == self.ENCODER_DIFF_CW:
             self.pd.HMI_ValueStruct.Bed_Temp += 1

--- a/klippy/extras/printerInterface.py
+++ b/klippy/extras/printerInterface.py
@@ -397,6 +397,10 @@ class PrinterData:
             )
         )
 
+    def sendGCode(self, Gcode):
+        gcode = self.printer.lookup_object('gcode')
+        gcode._process_commands([Gcode])
+
     def disable_all_heaters(self):
         self.setExtTemp(0)
         self.setBedTemp(0)


### PR DESCRIPTION
This PR reverts commit 0f6b57c97dc7bef6ccfa110a11e9f9eeaa13a0c8 (Fix Control tab temperature setting), which was originally merged in #142.

The reverted change introduced incorrect temperature behavior.
A corrected implementation will follow in a separate PR.